### PR TITLE
Fix minor issues related to wandb logging and configs/flags usage

### DIFF
--- a/elements/config.py
+++ b/elements/config.py
@@ -41,10 +41,10 @@ class Config(dict):
   def load(cls, filename):
     filename = path.Path(filename)
     if filename.suffix == '.json':
-      return cls(json.loads(filename.read_text()))
+      return cls(json.loads(filename.read()))
     elif filename.suffix in ('.yml', '.yaml'):
       import ruamel.yaml as yaml
-      return cls(yaml.safe_load(filename.read_text()))
+      return cls(yaml.safe_load(filename.read()))
     else:
       raise NotImplementedError(filename.suffix)
 

--- a/elements/flags.py
+++ b/elements/flags.py
@@ -10,7 +10,7 @@ class Flags:
     self._config = config.Config(*args, **kwargs)
 
   def parse(self, argv=None, help_exits=True):
-    parsed, remaining = self.parse_known(argv)
+    parsed, remaining = self.parse_known(argv, help_exits)
     for flag in remaining:
       if flag.startswith('--'):
         raise ValueError(f"Flag '{flag}' did not match any config keys.")

--- a/elements/logger.py
+++ b/elements/logger.py
@@ -287,7 +287,7 @@ class WandBOutput:
           value = (255 * np.clip(value, 0, 1)).astype(np.uint8)
         bystep[step][name] = wandb.Video(value)
     for step, metrics in bystep.items():
-      self._wandb.log(metrics, step=step)
+      wandb.log(metrics, step=step)
 
 
 class MLFlowOutput:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     long_description=pathlib.Path('README.md').read_text(),
     long_description_content_type='text/markdown',
     packages=['elements'],
-    install_requires=['numpy', 'imageio'],
+    install_requires=['numpy', 'imageio', 'matplotlib'],
     classifiers=[
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Hello!
Thank you for the package, looks really nice and helpful!

This PR contains the following fixes for some minor bugs:

- Add matplotlib to the list of requirements as it is imported in plotting.py
- In logger.py `self._wandb` is not defined, instead `.log()` is directly coming from the imported `wandb`
- In config.py the read method from `path.Path()` is named `read()` instead of `read_text()`
- In flags.py `help_exits` from `parse()` should be forwarded to `parse_known()` to allow printing the help page