### PR TITLE
Explicitly specify `mp4` format when logging to `wandb`.

### DIFF
--- a/elements/logger.py
+++ b/elements/logger.py
@@ -322,7 +322,7 @@ class WandBOutput:
         value = np.transpose(value, [0, 3, 1, 2])
         if value.dtype != np.uint8:
           value = (255 * np.clip(value, 0, 1)).astype(np.uint8)
-        bystep[step][name] = wandb.Video(value)
+        bystep[step][name] = wandb.Video(value, format='mp4')
 
     for step, metrics in bystep.items():
       self._wandb.log(metrics, step=step)


### PR DESCRIPTION
This very small PR ensures that videos logged to wandb are in mp4 format. Prior to this, wandb was defaulting to encoding videos as gifs. Switching to mp4 offers significantly better compression and smaller file sizes for longer videos.

Closes #11.

